### PR TITLE
Menu is not cleared when opening Drawer.

### DIFF
--- a/MaterialNavigationDrawerModule/src/main/java/it/neokree/materialnavigationdrawer/MaterialNavigationDrawer.java
+++ b/MaterialNavigationDrawerModule/src/main/java/it/neokree/materialnavigationdrawer/MaterialNavigationDrawer.java
@@ -798,7 +798,7 @@ public abstract class MaterialNavigationDrawer<Fragment> extends ActionBarActivi
     public boolean onPrepareOptionsMenu(Menu menu) {
 
         if(layout.isDrawerOpen(drawer) && !deviceSupportMultiPane()) {
-            menu.clear();
+            
         }
 
         return super.onPrepareOptionsMenu(menu);


### PR DESCRIPTION
This fixes a weird behavior when a section has options menu and you navigate to another which doesn't. The behavior was
-Open drawer & menu is cleared
-Select new section
-Drawer is closed and last section's menu was appearing a millisecond right the new was created.
